### PR TITLE
Fixed misspelling of package name in install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you don't have a plugins section add it. It should look like this:
 
 ```YAML
 plugins:
-  - serverless-aws-documenation
+  - serverless-aws-documentation
 ```
 
 If you wan't to check if the plugin was added successfully, you can run this in your command line:


### PR DESCRIPTION
Didn't want to let this one linger and cost anyone else time. 